### PR TITLE
added Sinon.SinonStub to union type in calledBefore/After

### DIFF
--- a/types/sinon-chai/index.d.ts
+++ b/types/sinon-chai/index.d.ts
@@ -43,21 +43,21 @@ declare global {
             /**
              * Returns true if the spy was called before anotherSpy.
              */
-            calledBefore(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall): Assertion;
+            calledBefore(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall|Sinon.SinonStub|Sinon.SinonStubCall): Assertion;
             /**
              * Returns true if the spy was called after anotherSpy.
              */
-            calledAfter(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall): Assertion;
+            calledAfter(anotherSpy: Sinon.SinonSpy|Sinon.SinonSpyCall|Sinon.SinonStub|Sinon.SinonStubCall): Assertion;
             /**
              * Returns true if spy was called before anotherSpy, and no spy calls occurred
              * between spy and anotherSpy.
              */
-            calledImmediatelyBefore(anotherSpy: Sinon.SinonSpy): Assertion;
+            calledImmediatelyBefore(anotherSpy: Sinon.SinonSpy|Sinon.SinonStub): Assertion;
             /**
              * Returns true if spy was called after anotherSpy, and no spy calls occurred
              * between anotherSpy and spy.
              */
-            calledImmediatelyAfter(anotherSpy: Sinon.SinonSpy): Assertion;
+            calledImmediatelyAfter(anotherSpy: Sinon.SinonSpy|Sinon.SinonStub): Assertion;
             /**
              * Returns true if spy/stub was called with the new operator. Beware that
              * this is inferred based on the value of the this object and the spy


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Sinon Stub API](https://sinonjs.org/releases/latest/stubs/)  

Stubs support the full api of spies. Unfortunately the following methods only supported spies, and didn't compile with stubs:
* calledBefore
* calledAfter
* calledImmediatelyBefore
* calledImmediatelyAfter